### PR TITLE
Improved 0.20 to 0.21 migration guide.

### DIFF
--- a/content/guide/15-migrating.md
+++ b/content/guide/15-migrating.md
@@ -241,7 +241,8 @@ const dev = NODE_ENV === 'development';
 polka() // You can also use Express
 	.use(
 		compression({ threshold: 0 }),
-		sirv('static', { dev }),
+-		sirv('assets', { dev }),
++		sirv('static', { dev }),
 -		sapper({ manifest })
 +		sapper.middleware()
 	)


### PR DESCRIPTION
While migrating my app I noticed a very minor issue in the diff example. I imagine someone else may run into this down the road.

I wasn't sure whether to do A or B. Let me know if you'd like me to switch the diff.

A (as it is):

```diff
- sirv('assets', { dev }),
+ sirv('static', { dev }),
- sapper({ manifest })
+ sapper.middleware()
```

B:

```diff
- sirv('assets', { dev }),
- sapper({ manifest })
+ sirv('static', { dev }),
+ sapper.middleware()
```