### PR TITLE
Update template instructions to use branches

### DIFF
--- a/content/guide/00-introduction.md
+++ b/content/guide/00-introduction.md
@@ -38,7 +38,10 @@ For web developers, the stakes are generally lower than for combat engineers. Bu
 The easiest way to start building a Sapper app is to clone the [sapper-template](https://github.com/sveltejs/sapper-template) repo with [degit](https://github.com/Rich-Harris/degit):
 
 ```js
-npx degit sveltejs/sapper-template my-app
+# for Rollup
+npx degit sveltejs/sapper-template#rollup my-app
+# for webpack
+npx degit sveltejs/sapper-template#webpack my-app
 cd my-app
 npm install
 npm run dev


### PR DESCRIPTION
Sapper's current docs will pull the template from master (which doesn't work). Must use either the rollup or webpack branch.