### PR TITLE
Quote hash-marks in commands

### DIFF
--- a/content/guide/00-introduction.md
+++ b/content/guide/00-introduction.md
@@ -38,8 +38,8 @@ For web developers, the stakes are generally lower than for combat engineers. Bu
 The easiest way to start building a Sapper app is to clone the [sapper-template](https://github.com/sveltejs/sapper-template) repo with [degit](https://github.com/Rich-Harris/degit):
 
 ```bash
-npx degit sveltejs/sapper-template#rollup my-app
-# or: npx degit sveltejs/sapper-template#webpack my-app
+npx degit 'sveltejs/sapper-template#rollup' my-app
+# or: npx degit 'sveltejs/sapper-template#webpack' my-app
 cd my-app
 npm install
 npm run dev


### PR DESCRIPTION
At least some shells (I'm using zsh) treat ```#``` as the start of comments, so you'd end up with:

```bash
npx degit 'sveltejs/sapper-template
```
instead of
```bash
npx degit 'sveltejs/sapper-template#rollup
```

So it's probably better to quote shell arguments that contain ```#``` to ensure they're passed to the command.